### PR TITLE
Call _strval when looking for an element in has().

### DIFF
--- a/lib/Set/Scalar/Base.pm
+++ b/lib/Set/Scalar/Base.pm
@@ -174,7 +174,7 @@ sub element {
 sub has {
     my $self = shift;
 
-    my @has = map { exists $self->{'elements'}->{ $_ } } @_;
+    my @has = map { exists $self->{'elements'}->{ _strval($_) } } @_;
 
     return wantarray ? @has : @_ > 1 ? grep { $_ } @has : $has[0];
 }

--- a/t/has.t
+++ b/t/has.t
@@ -1,8 +1,9 @@
 use Set::Scalar;
 
-print "1..3\n";
+print "1..5\n";
 
-my $s = Set::Scalar->new(qw(a b c 0));
+my $h = {t => 1};
+my $s = Set::Scalar->new(qw(a b c 0), $h);
 
 print "not " unless $s->has('a');
 print "ok 1\n";
@@ -13,3 +14,8 @@ print "ok 2\n";
 print "not " if $s->has('1');
 print "ok 3\n";
 
+print "not " unless $s->has($h);
+print "ok 4\n";
+
+print "not " if $s->has({t => 1});
+print "ok 5\n";


### PR DESCRIPTION
This fixes looking for references with `has()` and matches the way elements are found in `elements()`.
